### PR TITLE
get_season information

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,15 @@ dark = just_watch.get_title(title_id=55668, content_type='show')
 
 ```
 
+#### get further defails on a specific season of a tv program
 
+`season_id` can be found in the response from get_title of a tv program
+
+```python
+just_watch = JustWatch(country='GB')
+hannibal_season2 = just_watch.get_season(season_id=20236)
+
+```
 
 ##### Note: Default country is AU
 #### Read api_payload.txt for more information

--- a/justwatch/justwatchapi.py
+++ b/justwatch/justwatchapi.py
@@ -79,3 +79,13 @@ class JustWatch:
 
 		return r.json()
         
+	def get_season(self, season_id):
+
+		header = HEADER
+		api_url = 'https://apis.justwatch.com/content/titles/show_season/{}/locale/{}'.format(season_id, self.locale)
+		r = requests.get(api_url, headers=header)
+
+		# Client should deal with rate-limiting. JustWatch may send a 429 Too Many Requests response.
+		r.raise_for_status()   # Raises requests.exceptions.HTTPError if r.status_code != 200
+
+		return r.json()


### PR DESCRIPTION
I use this excellent api wrapper to find shows available to stream, however not _all seasons_ of a show are necessarily available.

`get_season` digs a little deeper to get more information from justwatch.