### PR TITLE
Add disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# JustWatchAPI
+# Unofficial JustWatch API
 [![Build Status](https://travis-ci.com/dawoudt/JustWatchAPI.svg?branch=master)](https://travis-ci.com/dawoudt/JustWatchAPI)
-
 
 JustWatch.com Python 3 API
 
@@ -8,6 +7,18 @@ JustWatch.com Python 3 API
 ```bash
 python3 -m pip install JustWatch
 ```
+
+##  Disclaimer
+This is not the official JustWatch API. JustWatch doesn't offer an open API and doesn't plan to do this in the future.
+
+The work of many developers went and is still going into the development and maintenance of the data and the API. JustWatch's main business is to operate a [streaming guide](https://www.justwatch.com/) with apps for iOS and Android. They offer the data for business intelligence and marketing. Therefore it is prohibited to use the API for commercial use (consumer service, data science, business intelligence, etc.). It is ok to use the API for private projects, but please be respectful with your API calls to not put too much load on the API. The API is not supported in any way and will change frequently without warning.
+
+If you would like to work with JustWatch and use the data/API please get in contact with them via [info@justwatch.com](mailto:info@justwatch.com). Currently, JustWatch can only work with bigger partners and clients.
+JustWatch is also hiring: https://www.justwatch.com/us/talent and has some interesting open source projects:
+
+- [JustWatch on Github](https://github.com/justwatchcom)
+- [GoPass Password Manager](https://github.com/gopasspw/gopass)
+
 ## How To
 #### search for an item
 ```python


### PR DESCRIPTION
Hey,

I'm an engineer at JustWatch and we get a bunch of support requests from people using this library as it's not explicitly labeled as an unofficial one. We don't have an official API and also no API documentation. Could you please add some disclaimer at the beginning of the README making it clear that this is an unofficial project? It also seems to not be clear to some people (https://github.com/dawoudt/JustWatchAPI/issues/8) so this would also be helpful for users of this library.

Thank you!
