### PR TITLE
Fix tests after User-Agent update

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -7,7 +7,7 @@ class TestJustWatchAPI(unittest.TestCase):
     def test_header(self):
         ''' Assert header has not changed'''
 
-        expected_header = {'User-Agent': 'JustWatch Python client (github.com/dawoudt/JustWatchAPI)'}
+        expected_header = {'User-Agent': 'JustWatch client (github.com/dawoudt/JustWatchAPI)'}
         header = justwatchapi.HEADER
         self.assertEqual(header, expected_header)
 


### PR DESCRIPTION
After the User-Agent update (https://github.com/dawoudt/JustWatchAPI/commit/0688a88dca8acd0af93fe8567f35e4dfb7aa5060), the test will fail becuase it's looking for the old User-Agent.

I fixed it. Now tests will be fine, and no longer red badge.